### PR TITLE
Add Window to WebIO example

### DIFF
--- a/Chapter3/using_webio.jl
+++ b/Chapter3/using_webio.jl
@@ -2,6 +2,8 @@
 using WebIO
 
 using Blink
+
+w = Window()
 # showing a text paragraph:
 body!(w, dom"p"("Hello from WebIO and Blink!"))
 


### PR DESCRIPTION
It adds the creation of the window to display the   two examples.